### PR TITLE
More standard graph node properties

### DIFF
--- a/src/files/index.js
+++ b/src/files/index.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const lockfiles = require('./lockfiles');
 const sandworm = require('./sandworm');
+const packages = require('./packages');
 const {loadJsonFile} = require('./utils');
 
 module.exports = {
   ...lockfiles,
   ...sandworm,
+  ...packages,
   loadManifest: (appPath) => loadJsonFile(path.join(appPath, 'package.json')),
 };

--- a/src/files/packages.js
+++ b/src/files/packages.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const loadInstalledPackages = async (rootPath, subPath = '') => {
+  let packageAtRootData;
+  const currentPath = path.join(rootPath, subPath);
+  try {
+    const manifestContent = await fs.promises.readFile(path.join(currentPath, 'package.json'), {
+      encoding: 'utf-8',
+    });
+    packageAtRootData = JSON.parse(manifestContent);
+    packageAtRootData.relativePath = subPath;
+  // eslint-disable-next-line no-empty
+  } catch (error) {}
+
+  const subdirectories = (await fs.promises.readdir(currentPath, {withFileTypes: true}))
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+
+  const allChildren = await subdirectories.reduce(async (previous, subdir) => {
+    const children = await previous;
+    const subDirChildren = await loadInstalledPackages(rootPath, path.join(subPath, subdir));
+
+    return [...children, ...subDirChildren];
+  }, Promise.resolve([]));
+
+  return packageAtRootData ? [packageAtRootData, ...allChildren] : allChildren;
+};
+
+module.exports = {loadInstalledPackages};

--- a/src/graph/generateNpmGraph.js
+++ b/src/graph/generateNpmGraph.js
@@ -21,23 +21,14 @@ const generateNpmGraph = ({packages}) => {
       version,
       resolved,
       integrity,
-      dev,
-      optional,
-      license,
-      engines,
     } = packageData;
     const name = originalName || packageNameFromPath(packageLocation);
 
     const newPackage = makeNode({
       name,
       version,
-      relativePath: packageLocation,
       ...(resolved && {resolved}),
       ...(integrity && {integrity}),
-      ...(license && {license}),
-      ...(engines && {engines}),
-      ...(dev && {dev}),
-      ...(optional && {optional}),
     });
 
     if (packageLocation === '') {

--- a/src/graph/generatePnpmGraph.js
+++ b/src/graph/generatePnpmGraph.js
@@ -36,8 +36,6 @@ const generatePnpmGraph = ({data, manifest}) => {
       dev,
       // peerDependenciesMeta
       // transitivePeerDependencies,
-      // engines,
-      // hasBin,
     } = packageData;
     const {name, version} = parsePath(id);
     const newPackage = makeNode({

--- a/src/graph/index.js
+++ b/src/graph/index.js
@@ -1,4 +1,4 @@
-const {loadLockfile, loadManifest} = require('../files');
+const {loadLockfile, loadManifest, loadInstalledPackages} = require('../files');
 const generateNpmGraph = require('./generateNpmGraph');
 const generatePnpmGraph = require('./generatePnpmGraph');
 const generateYarnGraph = require('./generateYarnGraph');
@@ -28,11 +28,14 @@ const generateGraphPromise = async (appPath) => {
     });
   }
 
+  const installedPackages = await loadInstalledPackages(appPath);
+
   const {root, allPackages} = graph;
+  const processedRoot = postProcessGraph({root, installedPackages});
 
   return {
     root: {
-      ...(postProcessGraph(root) || {}),
+      ...(processedRoot || {}),
       meta: {lockfileVersion: lockfile.lockfileVersion, packageManager: lockfile.manager},
     },
     all: allPackages,
@@ -49,7 +52,7 @@ const generateGraphAsync = (appPath, done = () => {}) => {
 }
 
 const generateGraph = (appPath, done) => {
-  if (done) {
+  if (typeof done === 'function') {
     return generateGraphAsync(appPath, done);
   }
 


### PR DESCRIPTION
Dependency graph nodes now have the following new props:
- `license` - spdx license as declared in the manifest
- `engines` - as declared in the manifest
- `relativePath` - relative path from the app root to the installed package

A new `files/loadInstalledPackages` export is also available, that recursively loads every package manifest file within a given root directory.

Closes #13 